### PR TITLE
DEV-23888 - Fixes alignment issues in the frogger thumbnails (FF and IE11)

### DIFF
--- a/src/scss/arcades/_frogger.scss
+++ b/src/scss/arcades/_frogger.scss
@@ -112,7 +112,7 @@
   }
 
   .arcade__line--beta {
-    @include align-items(flex-end);
+    @include align-items(stretch);
 
     @include webkit-only() {
       -webkit-box-direction: normal;


### PR DESCRIPTION
The alignment issue was with content in the beta line of the thumbnail